### PR TITLE
Load tokenizer with external text encoder

### DIFF
--- a/model_loader.py
+++ b/model_loader.py
@@ -92,9 +92,9 @@ class NunchakuModelLoader:
 
             torch_dtype = torch.bfloat16 if self.device == "cuda" else torch.float32
 
-            # Attempt to load external text encoder
+            # Attempt to load external text encoder and tokenizer
             try:
-                from transformers import CLIPTextModel
+                from transformers import CLIPTextModel, CLIPTokenizer
 
                 text_encoder = CLIPTextModel.from_pretrained(
                     "RedHatAI/Qwen2.5-VL-7B-Instruct-FP8-Dynamic",
@@ -108,6 +108,18 @@ class NunchakuModelLoader:
                 )
                 return False
 
+            try:
+                tokenizer = CLIPTokenizer.from_pretrained(
+                    "RedHatAI/Qwen2.5-VL-7B-Instruct-FP8-Dynamic"
+                )
+                logger.info("Tokenizer loaded successfully.")
+            except Exception as e:
+                logger.error(
+                    "Failed to load tokenizer 'RedHatAI/Qwen2.5-VL-7B-Instruct-FP8-Dynamic': %s",
+                    e,
+                )
+                return False
+
             # Load the pipeline from the single quantized file
             try:
                 if _scipy_available:
@@ -116,6 +128,7 @@ class NunchakuModelLoader:
                         torch_dtype=torch_dtype,
                         use_safetensors=True,
                         text_encoder=text_encoder,
+                        tokenizer=tokenizer,
                     )
                     # Prefer DPM++ 2M when SciPy is available
                     self.pipeline.scheduler = _Scheduler.from_config(
@@ -136,6 +149,7 @@ class NunchakuModelLoader:
                         use_safetensors=True,
                         scheduler=scheduler,
                         text_encoder=text_encoder,
+                        tokenizer=tokenizer,
                     )
                 logger.info("Pipeline loaded successfully from single file.")
             except Exception as e:


### PR DESCRIPTION
## Summary
- load CLIPTokenizer with the external text encoder
- provide tokenizer to StableDiffusionPipeline
- handle errors when tokenizer fails to load

## Testing
- `pytest`
- `python -m py_compile model_loader.py`

------
https://chatgpt.com/codex/tasks/task_b_68a02e1e0f848329b4d4169e4e6b8b68